### PR TITLE
Set Version and Hash as Build Args

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,10 @@
+ARG WORDPRESS_VERSION=5.7
+ARG WORDPRESS_SHA1=76d1332cfcbc5f8b17151b357999d1f758faf897
+
 FROM mariadb:10.5
+ARG WORDPRESS_VERSION
+ARG WORDPRESS_SHA1
+
 LABEL maintainer "Alice Su <toalice@protonmail.com>" architecture="AMD64/x86_64"
 LABEL mariadb-version="10.5"
 
@@ -75,8 +81,8 @@ RUN set -eux; \
 # (replace all instances of "%h" with "%a" in LogFormat)
 	find /etc/apache2 -type f -name '*.conf' -exec sed -ri 's/([[:space:]]*LogFormat[[:space:]]+"[^"]*)%h([^"]*")/\1%a\2/g' '{}' +
 
-ENV WORDPRESS_VERSION 5.7
-ENV WORDPRESS_SHA1 76d1332cfcbc5f8b17151b357999d1f758faf897
+ENV WORDPRESS_VERSION=${WORDPRESS_VERSION}
+ENV WORDPRESS_SHA1=${WORDPRESS_SHA1}
 
 RUN set -ex; \
 	curl -o wordpress.tar.gz -fSL "https://wordpress.org/wordpress-${WORDPRESS_VERSION}.tar.gz"; \


### PR DESCRIPTION
Sets the version and hash for the download of the WordPress tarball as build args, so these may be overwritten for a different version.

Seems to work for me so far bumping to 6.2, although obviously more changes may be needed to support different versions properly.